### PR TITLE
Adding Call Cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ Bug Fixes:
 * Fixed a bug in the preflight system which sometimes displayed outdated preflight results
 * Fixed a missing success notification when uploading new method configurations
 
+New Features:
+* Lapdog now supports an optional per-workspace call-cache
+
 ### Cromwell Changes
 
 These changes have been applied to the global Lapdog Cromwell docker image and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased Changes
+## 0.17.0 (Beta)
 
 Bug Fixes:
 * Fixed a bug which sometimes prevented functions from being deployed during a patch
@@ -10,10 +10,13 @@ Bug Fixes:
 New Features:
 * Lapdog now supports an optional per-workspace call-cache
 
-### Cromwell Changes
+Other changes:
+* Updated Dalmatian to 0.0.11
 
-These changes have been applied to the global Lapdog Cromwell docker image and
-will effect all Lapdog clients running >= 0.15.0:
+### Additional Cromwell Changes
+
+These additional changes have also been backported to the global Cromwell images used
+by Lapdog versions 0.15.0-0.16.4.
 
 * Significantly improved latency of Cromwell log
 * Updated to Cromwell 41. This allows worker VMs to be labeled by their parent submission id

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ by Lapdog versions 0.15.0-0.16.4.
 * Significantly improved latency of Cromwell log
 * Updated to Cromwell 41. This allows worker VMs to be labeled by their parent submission id
 
+### Patch Contents:
+* Updated `submit` endpoint to v7 to accommodate call-cache
 
 ## 0.16.4 (Beta)
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ read the development roadmap.
 
 ##### Cons
 * You pay an additional 5¢/hour fee for each submission to run the Cromwell server
-* There is no call cache in Lapdog yet. This is still in development
 * Submission results must be manually uploaded to Firecloud by clicking the `Upload Results` button in the UI.
 * There are small overhead costs billed to the Lapdog Engine for operation. These costs
 are for calls to the API and for storage of metadata, both of which should be very cheap

--- a/lapdog/__main__.py
+++ b/lapdog/__main__.py
@@ -441,7 +441,7 @@ def cmd_submissions(args):
     submissions = args.workspace.get_submission_status(filter_active=args.done)
     if args.id:
         submissions=submissions[
-            submissions['submission_id'] == args.id
+            submissions['submissionId'] == args.id
         ]
     if args.config:
         submissions=submissions[

--- a/lapdog/api/controllers.py
+++ b/lapdog/api/controllers.py
@@ -544,7 +544,7 @@ def preflight(namespace, name, config, entity, expression="", etype=""):
         }, 200
 
 @controller
-def execute(namespace, name, config, entity, expression="", etype="", memory=3, batch=250, query=100, private=False, region=None):
+def execute(namespace, name, config, entity, expression="", etype="", memory=3, batch=250, cache=True, private=False, region=None):
     ws = get_workspace_object(namespace, name)
     try:
         global_id, local_id, operation_id = ws.execute(
@@ -553,9 +553,9 @@ def execute(namespace, name, config, entity, expression="", etype="", memory=3, 
             expression if expression != "" else None,
             etype if etype != "" else None,
             force=True,
+            use_cache=cache,
             memory=memory,
             batch_limit=batch,
-            query_limit=query,
             private=private,
             region=region
         )

--- a/lapdog/api/swagger/lapdog.yaml
+++ b/lapdog/api/swagger/lapdog.yaml
@@ -1091,11 +1091,11 @@ paths:
           default: 250
         -
           in: query
-          name: query
+          name: cache
           required: false
-          type: integer
-          description: Number of jobs to query at once (optional)
-          default: 100
+          type: boolean
+          description: Enables use of the workspace call cache (optional)
+          default: true
         -
           in: query
           name: private

--- a/lapdog/cloud/abort.py
+++ b/lapdog/cloud/abort.py
@@ -13,8 +13,6 @@ import traceback
 def abort_submission(request):
     try:
 
-        # https://genomics.googleapis.com/google.genomics.v2alpha1.Pipelines
-
         data = request.get_json()
 
         # 1) Validate the token

--- a/lapdog/cloud/submit.py
+++ b/lapdog/cloud/submit.py
@@ -210,6 +210,11 @@ def create_submission(request):
                             'SUBMISSION_ZONES': " ".join(
                                 '{}-{}'.format(region, zone)
                                 for zone in GCP_ZONES[region]
+                            ),
+                            'DUMP_PATH': (
+                                ("gs://{bucket}/lapdog-call-cache.sql".format(bucket=data['bucket']))
+                                if 'callcache' in data and data['callcache']
+                                else ""
                             )
                         }
                     }

--- a/lapdog/cloud/submit.py
+++ b/lapdog/cloud/submit.py
@@ -159,7 +159,7 @@ def create_submission(request):
 
         if 'memory' in data and data['memory'] > 3072:
             mtype = 'custom-%d-%d' % (
-                math.ceil(data['memory']/13312)*2,
+                math.ceil(data['memory']/13312)*2, # Cheapest core:memory ratio
                 data['memory']
             )
         else:
@@ -238,7 +238,9 @@ def create_submission(request):
                                 "https://www.googleapis.com/auth/genomics"
                             ]
                         },
-                        'bootDiskSizeGb': 20,
+                        'bootDiskSizeGb': 20 + (
+                            max(0, data['cache_size'] - 10) if 'cache_size' in data else 0
+                        ),
                         'network': {
                             'name': 'default',
                             'usePrivateAddress': ('no_ip' in data and data['no_ip'])

--- a/lapdog/cloud/utils.py
+++ b/lapdog/cloud/utils.py
@@ -18,7 +18,7 @@ import traceback
 
 # TODO: Update all endpoints to v1 for release
 __API_VERSION__ = {
-    'submit': 'v7dev',
+    'submit': 'v7',
     'abort': 'v2',
     'register': 'v3',
     'signature': 'v2',
@@ -36,7 +36,7 @@ __API_VERSION__ = {
 # This function will deploy new cloud functions and run any other arbitrary code
 # Such as updating iam policy bindings or role permissions
 
-__CROMWELL_TAG__ = 'mysql-test'
+__CROMWELL_TAG__ = 'v0.17.0'
 
 GCP_ZONES = {
     'asia-east1':	('a', 'b', 'c'),

--- a/lapdog/cloud/utils.py
+++ b/lapdog/cloud/utils.py
@@ -18,7 +18,7 @@ import traceback
 
 # TODO: Update all endpoints to v1 for release
 __API_VERSION__ = {
-    'submit': 'v6',
+    'submit': 'v7dev',
     'abort': 'v2',
     'register': 'v3',
     'signature': 'v2',
@@ -36,7 +36,7 @@ __API_VERSION__ = {
 # This function will deploy new cloud functions and run any other arbitrary code
 # Such as updating iam policy bindings or role permissions
 
-__CROMWELL_TAG__ = 'v0.15.0'
+__CROMWELL_TAG__ = 'mysql-test'
 
 GCP_ZONES = {
     'asia-east1':	('a', 'b', 'c'),

--- a/lapdog/cromwell/Dockerfile
+++ b/lapdog/cromwell/Dockerfile
@@ -5,6 +5,18 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 FROM java:openjdk-8-jre
+MAINTAINER Aaron Graubert
+
+# Fix apt repositories
+RUN rm /etc/apt/sources.list.d/jessie-backports.list && \
+  printf "deb http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
+
+#Install mysql
+RUN apt-get update && \
+    echo 'mysql-server mysql-server/root_password password cromwell' | debconf-set-selections && \
+    echo 'mysql-server mysql-server/root_password_again password cromwell' | debconf-set-selections && \
+    apt-get install mysql-server -y
 
 # Install python
 RUN apt-get update && \

--- a/lapdog/cromwell/cromwell_driver.py
+++ b/lapdog/cromwell/cromwell_driver.py
@@ -161,16 +161,16 @@ class CromwellDriver(object):
 
                     chunk = []
 
-                    if not first:
-                        logging.info("Restarting cromwell...")
-                        self.cromwell_proc.kill()
-                        self.cromwell_proc = None
-                        time.sleep(10)
-                        self.start(self.mem)
-                        time.sleep(20)
-                        logging.info("Resuming next batch")
-                    else:
-                        first = False
+                    # if not first:
+                    #     logging.info("Restarting cromwell...")
+                    #     self.cromwell_proc.kill()
+                    #     self.cromwell_proc = None
+                    #     time.sleep(10)
+                    #     self.start(self.mem)
+                    #     time.sleep(20)
+                    #     logging.info("Resuming next batch")
+                    # else:
+                    #     first = False
 
                     for group in clump(batch, query_limit):
                         logging.info("Starting a chunk of %d workflows" % query_limit)

--- a/lapdog/cromwell/cromwell_driver.py
+++ b/lapdog/cromwell/cromwell_driver.py
@@ -161,16 +161,16 @@ class CromwellDriver(object):
 
                     chunk = []
 
-                    # if not first:
-                    #     logging.info("Restarting cromwell...")
-                    #     self.cromwell_proc.kill()
-                    #     self.cromwell_proc = None
-                    #     time.sleep(10)
-                    #     self.start(self.mem)
-                    #     time.sleep(20)
-                    #     logging.info("Resuming next batch")
-                    # else:
-                    #     first = False
+                    if not first:
+                        logging.info("Restarting cromwell...")
+                        self.cromwell_proc.kill()
+                        self.cromwell_proc = None
+                        time.sleep(10)
+                        self.start(self.mem)
+                        time.sleep(20)
+                        logging.info("Resuming next batch")
+                    else:
+                        first = False
 
                     for group in clump(batch, query_limit):
                         logging.info("Starting a chunk of %d workflows" % query_limit)

--- a/lapdog/cromwell/jes_template.tmp.conf
+++ b/lapdog/cromwell/jes_template.tmp.conf
@@ -2,6 +2,11 @@
 
 system {
   max-concurrent-workflows = 10000
+  max-workflow-launch-count = 100
+  io {
+    number-of-requests = 2000
+    per = 100 seconds
+  }
 }
 
 webservice {
@@ -82,13 +87,18 @@ google {
 }
 
 database {
-  profile = "slick.jdbc.HsqldbProfile$"
-
+  profile = "slick.jdbc.MySQLProfile$"
   db {
-    driver = "org.hsqldb.jdbcDriver"
-    url = "jdbc:hsqldb:mem:${slick.uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
-    connectionTimeout = 3000
+    driver = "com.mysql.cj.jdbc.Driver"
+    url = "jdbc:mysql://localhost/cromwell?rewriteBatchedStatements=true"
+    user = "root"
+    password = "cromwell"
+    connectionTimeout = 5000
   }
+}
+
+call-caching {
+  enabled = true
 }
 
 instrumentation {

--- a/lapdog/cromwell/logger.py
+++ b/lapdog/cromwell/logger.py
@@ -47,7 +47,6 @@ def abort_worker():
     while True:
         for i in range(60):
             time.sleep(2)
-        print("CHECKING ABORT KEY")
         if subprocess.call('gsutil ls %s' % abort_path, shell=True) == 0:
             # abort key located
             print("ABORTING")

--- a/lapdog/gateway.py
+++ b/lapdog/gateway.py
@@ -708,7 +708,7 @@ class Gateway(object):
             raise ValueError("Gateway failed to register user")
         return response.text # your account email
 
-    def create_submission(self, workspace, bucket, submission_id, workflow_options=None, memory=3, private=False, region=None):
+    def create_submission(self, workspace, bucket, submission_id, workflow_options=None, use_cache=True, memory=3, private=False, region=None, _cache_size=None):
         """
         Sends a request through the lapdog execution API to start a new submission.
         Takes the local submission ID.
@@ -725,6 +725,11 @@ class Gateway(object):
         download the input files specified in the workflow inputs.
         """
         warnings.warn("[BETA] Gateway Create Submission")
+        if _cache_size is None and use_cache:
+            blob = getblob('gs://{}/lapdog-call-cache.sql'.format(bucket))
+            if blob.exists():
+                blob.reload()
+                _cache_size = blob.size
         response = get_user_session().post(
             self.get_endpoint('submit'),
             headers={'Content-Type': 'application/json'},
@@ -737,7 +742,8 @@ class Gateway(object):
                 'memory': memory*1024,
                 'no_ip': private,
                 'compute_region': region,
-                'callcache': True
+                'callcache': use_cache,
+                'cache_size': _cache_size / 1073741824 # 1gib
             }
         )
         if response.status_code == 200:

--- a/lapdog/gateway.py
+++ b/lapdog/gateway.py
@@ -736,7 +736,8 @@ class Gateway(object):
                 'workflow_options': workflow_options if workflow_options is not None else {},
                 'memory': memory*1024,
                 'no_ip': private,
-                'compute_region': region
+                'compute_region': region,
+                'callcache': True
             }
         )
         if response.status_code == 200:

--- a/lapdog/lapdog.py
+++ b/lapdog/lapdog.py
@@ -493,7 +493,7 @@ class WorkspaceManager(dog.WorkspaceManager):
             'workspace':self.workspace,
             'namespace':self.namespace,
             'identifier':global_id,
-            'submission_id': submission_id,
+            'submissionId': submission_id,
             'methodConfigurationName':preflight.config['name'],
             'methodConfigurationNamespace':preflight.config['namespace'],
             'status': 'Running',
@@ -505,7 +505,7 @@ class WorkspaceManager(dog.WorkspaceManager):
                 'entityName': preflight.entity,
                 'entityType': preflight.etype
             },
-            'submitter': 'lapdog',
+            'submitter': self.hound.author,
             'workflowEntityType': preflight.config['rootEntityType'],
             'workflowExpression': expression if expression is not None else None,
             'runtime': {

--- a/lapdog/vue/src/Pages/Submission.vue
+++ b/lapdog/vue/src/Pages/Submission.vue
@@ -363,6 +363,16 @@ Other: error_outline
       </div>
     </div>
     <div class="workflow-container" v-if="workflows && workflows.length">
+      <div class="row" v-bind:title="completed_workflows.length +'/' + submission.workflows.length">
+        <div class="col s2">
+          Submission progress
+        </div>
+        <div class="col s10">
+          <div class="progress">
+            <div class="determinate blue" v-bind:style="'width: '+100*completed_workflows.length/submission.workflows.length+'%'"></div>
+          </div>
+        </div>
+      </div>
       <pagination ref="pagination" v-bind:n_pages="lodash.ceil(workflows.length / 20)" v-bind:page_size="20" v-bind:getter="turn_page"></pagination>
       <table class="highlight">
         <thead>
@@ -440,7 +450,8 @@ export default {
       rerun_set: null,
       rerun_type: null,
       page: 0,
-      cancel: null
+      cancel: null,
+      final_status: new Set(['Success', 'Failed', 'Cancelled'])
     }
   },
   computed: {
@@ -459,6 +470,9 @@ export default {
     },
     visible_workflows() {
       return _.slice(this.workflows, this.page * 20, (this.page + 1) * 20);
+    },
+    completed_workflows() {
+      return _.filter(this.workflows, (wf) => {return this.final_status.has(wf.status)});
     }
   },
   created() {

--- a/lapdog/vue/src/Pages/Submission.vue
+++ b/lapdog/vue/src/Pages/Submission.vue
@@ -364,10 +364,10 @@ Other: error_outline
     </div>
     <div class="workflow-container" v-if="workflows && workflows.length">
       <div class="row" v-bind:title="completed_workflows.length +'/' + submission.workflows.length">
-        <div class="col s2">
-          Submission progress
+        <div class="col s3">
+          Submission Completion <span class="right">{{completed_workflows.length}} / {{submission.workflows.length}}</span>
         </div>
-        <div class="col s10">
+        <div class="col s9">
           <div class="progress">
             <div class="determinate blue" v-bind:style="'width: '+100*completed_workflows.length/submission.workflows.length+'%'"></div>
           </div>

--- a/lapdog/vue/src/Pages/Workspace.vue
+++ b/lapdog/vue/src/Pages/Workspace.vue
@@ -94,6 +94,21 @@
             </div>
             <div class="row">
               <div class="col s3">
+                Call Cache
+              </div>
+              <div class="col s9">
+                <div class="switch">
+                  <label>
+                    Disabled
+                    <input checked type="checkbox" v-model="callcache">
+                    <span class="lever"></span>
+                    Enabled (Recommended)
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col s3">
                 Compute Region
               </div>
               <div class="col s9 input-field" style="margin-top: 0px !important;">
@@ -111,10 +126,10 @@
                 Cromwell Memory
               </div>
               <div class="col s7">
-                <input v-model="cromwell_mem" class="blue-text" type="range" name="cromwell-mem" min="3" max="624" step="1" value="3" v-on:change="batch_size = cromwell_mem == 3 ? 250 : Math.floor(0.75 * cromwell_mem * 250/3)">
+                <input v-model="cromwell_mem" class="blue-text" type="range" name="cromwell-mem" min="3" max="624" step="1" value="3" v-on:change="batch_size = cromwell_mem == 3 ? 1500 : Math.floor(0.75 * cromwell_mem * 500)">
               </div>
               <div class="col s2">
-                {{cromwell_mem}} GB ${{
+                {{cromwell_mem}} GB ~${{
                   //Math.floor((cromwell_mem == 3 ? 0.05 : 0.063222 + (0.004237 * lodash.min([13, cromwell_mem]) ) + (cromwell_mem > 13 ? 0.009550 * (cromwell_mem - 13): 0))*100)/100
                   cromwell_mem == 3 ? 0.05 : Math.floor((
                     (Math.ceil(cromwell_mem/13) * 0.066348) + //core cost
@@ -128,21 +143,10 @@
                 Max Concurrent Workflows
               </div>
               <div class="col s7">
-                <input v-model="batch_size" class="blue-text" type="range" name="cromwell-mem" min="100" v-bind:max="Math.floor(cromwell_mem * 250/3)" step="1" value="250">
+                <input v-model="batch_size" class="blue-text" type="range" name="cromwell-mem" min="100" v-bind:max="Math.floor(cromwell_mem * 500)" step="1" value="1500">
               </div>
               <div class="col s2">
                 {{batch_size}} Jobs
-              </div>
-            </div>
-            <div class="row">
-              <div class="col s3">
-                Workflow Dispatch Rate
-              </div>
-              <div class="col s7">
-                <input v-model="query_size" class="blue-text" type="range" name="cromwell-mem" min="1" v-bind:max="batch_size" step="1" value="250">
-              </div>
-              <div class="col s2">
-                {{query_size}} Jobs/chunk
               </div>
             </div>
           </div>
@@ -359,8 +363,8 @@
                 </td>
                 <td>{{sub.submissionDate}}</td>
                 <td>
-                  <router-link :to="{name: 'submission', params: {namespace:sub.namespace, workspace:sub.workspace, submission_id:sub.submission_id}}">
-                    {{sub.submission_id}}
+                  <router-link :to="{name: 'submission', params: {namespace:sub.namespace, workspace:sub.workspace, submission_id:sub.submission_id || sub.submissionId}}">
+                    {{sub.submission_id || sub.submissionId}}
                   </router-link>
                 </td>
               </tr>
@@ -503,8 +507,8 @@
         preflight_entities: 0,
         show_advanced: false,
         cromwell_mem: 3,
-        batch_size: 250,
-        query_size: 100,
+        batch_size: 1500,
+        callcache: true,
         cached_submissions: true,
         gateway: null,
         pending_ops: 0,
@@ -670,19 +674,15 @@
           entity: this.entity_field,
           memory: this.cromwell_mem,
           batch: this.batch_size,
-          query: this.query_size,
+          cache: this.callcache,
           private: this.private_access,
           region: this.compute_region
         }
         if (this.submission_expression != "") params.expression = this.submission_expression;
         if (this.submission_etype != "") params.etype = this.submission_etype;
 
-        if (this.preflight_entities > 500) window.materialize.toast({
+        window.materialize.toast({
           html: "Preparing job. This may take a while...",
-          displayLength: 10000,
-        })
-        else window.materialize.toast({
-          html: "Preparing job...",
           displayLength: 10000,
         })
         axios.post(
@@ -764,8 +764,8 @@
         this.entities_data = null;
         this.show_advanced = false;
         this.cromwell_mem = 3;
-        this.batch_size = 250;
-        this.query_size = 100;
+        this.batch_size = 1500;
+        this.callcache = true;
         this.cached_submissions = true;
         this.cache_state = true;
         this.syncing = false;
@@ -888,7 +888,7 @@
           () => {window.$('input.autocomplete').autocomplete({
             limit: 6
           })},
-          250
+          1500
         );
       },
       bind_autocomplete_listener() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 firecloud>=0.16.9
-firecloud-dalmatian>=0.0.9
+firecloud-dalmatian>=0.0.11
 google-cloud-storage>=1.13.2
 PyYAML>=5.1
 agutil>=4.0.2


### PR DESCRIPTION
# Lapdog Call Caching System

## Overview

Each workspace will contain an independent call cache, which can be used to skip previously succeeded jobs. As a cache-enabled submission starts, cromwell will download the current workspace call cache to it's local mysql database. After the submission ends, the updated state of the database is saved back to the workspace bucket.

## Todo

- [x] 100 Workflow scale test
- [x] 100 Workflow cache hit test
- [x] Memory Benchmarking
- [x] Deprecate `Query Limit` and remove from UI
- [x] Add `Enable/Disable Call Cache` as option to UI and python
- [x] 100 Workflow scale test (cache disabled)
- [x] 100 Workflow scale test (cache enabled)
- [x] 1000 Workflow scale test
- [x] Test concurrent call cache overwrites
- [x] Add dynamic scaling boot disk size: `20 + max(0, cache - 10)`